### PR TITLE
Put redis back

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,8 @@ version: "3.8"
 
 services:
   redis:
-    container_name: redis-wej
+    container_name: redis-partz
+    restart: always
     image: "redis:alpine"
     hostname: redis
     ports:
@@ -10,7 +11,7 @@ services:
     volumes:
       - redis-data:/data
   # mongo:
-  #   container_name: mongo-wej
+  #   container_name: mongo-partz
   #   image: mongo
   #   restart: unless-stopped
   #   env_file: .env

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest --verbose",
     "start": "npm run build:ts && NODE_ENV=production fastify start -l info dist/app.js",
     "build:ts": "tsc",
+    "docker": "docker-compose up -d",
     "dev": "tsc && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"tsc -w\" \"fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js\"",
     "prepare": "husky install"
   },
@@ -32,12 +33,12 @@
     "fastify-jwt": "^4.0.0",
     "fastify-plugin": "^3.0.0",
     "fastify-rate-limit": "^5.6.2",
+    "fastify-redis": "^4.3.3",
     "fastify-sensible": "^3.1.2",
     "fastify-swagger": "^4.12.6",
     "fastify-tsconfig": "^1.0.1",
     "mailgun-js": "^0.22.0",
     "mongoose": "^6.0.13",
-    "redis": "^4.0.0",
     "redis-mock": "^0.56.3",
     "typescript": "^4.5.2"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { FastifyPluginAsync } from "fastify";
 import AutoLoad, { AutoloadPluginOptions } from "fastify-autoload";
 import * as mongoose from "mongoose";
-import { decorateFastify } from "./helpers/mutateFastify";
+import { addCachingHooks, decorateFastify } from "./helpers/mutateFastify";
 
 // import { resetMongoose } from "./helpers/resetMongoose";
 
@@ -22,6 +22,7 @@ const app: FastifyPluginAsync<AppOptions> = async (
   }
 
   decorateFastify(fastify);
+  addCachingHooks(fastify);
 
   // await resetMongoose(mongoose);
 

--- a/src/fastify.d.ts
+++ b/src/fastify.d.ts
@@ -9,6 +9,5 @@ declare module "fastify" {
   }
   interface FastifyRequest {
     user: UserDoc;
-    isCached: boolean;
   }
 }

--- a/src/helpers/mutateFastify.ts
+++ b/src/helpers/mutateFastify.ts
@@ -1,7 +1,63 @@
-import { FastifyInstance } from "fastify";
+import {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  HookHandlerDoneFunction,
+} from "fastify";
 
 import { getUserInfoIfLogged } from "../utils/authorization/getUserInfoIfLogged";
 
 export const decorateFastify = (fastify: FastifyInstance) => {
   fastify.decorate("getUserInfoIfLogged", getUserInfoIfLogged);
+};
+
+export const addCachingHooks = (fastify: FastifyInstance) => {
+  fastify.addHook(
+    "onRequest",
+    async function (
+      req: FastifyRequest<{ Params: { id: string } }>,
+      rep: FastifyReply
+    ) {
+      if (req.method === "GET" && !!req.params.id) {
+        const result = await fastify.redis.get(req.params.id);
+
+        if (result) return rep.status(202).send(JSON.parse(result));
+      }
+      return;
+    }
+  );
+  fastify.addHook(
+    "onSend",
+    function (
+      req: FastifyRequest<{ Params: { id: string } }>,
+      _rep: FastifyReply,
+      payload: string,
+      done: HookHandlerDoneFunction
+    ) {
+      const isMutatingData = req.method === "POST" || req.method === "PUT";
+
+      if (isMutatingData) {
+        const object = JSON.parse(payload);
+        if (object.id) {
+          fastify.redis.set(object.id, payload);
+        }
+      }
+
+      done();
+    }
+  );
+  fastify.addHook(
+    "onResponse",
+    function (
+      req: FastifyRequest<{ Params: { id: string } }>,
+      _rep: FastifyReply,
+      done: HookHandlerDoneFunction
+    ) {
+      if (req.method === "DELETE" && !!req.params.id) {
+        fastify.redis.del(req.params.id);
+        console.info("I got removed from cache!");
+      }
+      done();
+    }
+  );
 };

--- a/src/helpers/mutateFastify.ts
+++ b/src/helpers/mutateFastify.ts
@@ -19,7 +19,7 @@ export const addCachingHooks = (fastify: FastifyInstance) => {
       rep: FastifyReply
     ) {
       if (req.method === "GET" && !!req.params.id) {
-        const result = await fastify.redis.get(req.params.id);
+        const result = await fastify.redis?.get(req.params.id);
 
         if (result) return rep.status(202).send(JSON.parse(result));
       }
@@ -39,7 +39,7 @@ export const addCachingHooks = (fastify: FastifyInstance) => {
       if (isMutatingData) {
         const object = JSON.parse(payload);
         if (object.id) {
-          fastify.redis.set(object.id, payload);
+          fastify.redis?.set(object.id, payload);
         }
       }
 
@@ -54,8 +54,7 @@ export const addCachingHooks = (fastify: FastifyInstance) => {
       done: HookHandlerDoneFunction
     ) {
       if (req.method === "DELETE" && !!req.params.id) {
-        fastify.redis.del(req.params.id);
-        console.info("I got removed from cache!");
+        fastify.redis?.del(req.params.id);
       }
       done();
     }

--- a/src/plugins/redis.ts
+++ b/src/plugins/redis.ts
@@ -13,7 +13,6 @@ export default fp(async (fastify) => {
   );
 
   if (stdout.includes("true")) {
-    console.log("coucou");
     fastify.register<FastifyRedisPluginOptions>(fastifyRedis, {
       host: "127.0.0.1",
     });

--- a/src/plugins/redis.ts
+++ b/src/plugins/redis.ts
@@ -1,20 +1,21 @@
-import { exec } from "child_process";
 import fp from "fastify-plugin";
 import fastifyRedis, { FastifyRedisPluginOptions } from "fastify-redis";
+import { exec } from "child_process";
+import { promisify } from "util";
 
-let IS_REDIS_ONLINE: boolean;
-
-exec(
-  `echo "$( docker container inspect -f '{{.State.Running}}' "redis-partz")"`,
-  (_error, stdout) => {
-    IS_REDIS_ONLINE = stdout.includes("true");
-  }
-);
+const execAwait = promisify(exec);
 
 export default fp(async (fastify) => {
-  if (IS_REDIS_ONLINE) {
+  const { stdout } = await execAwait(
+    `echo "$( docker container inspect -f '{{.State.Running}}' "redis-partz")"`
+  );
+
+  console.log(`stdout`, stdout);
+
+  if (stdout.includes("true")) {
+    console.log("coucou");
     fastify.register<FastifyRedisPluginOptions>(fastifyRedis, {
-      url: process.env.REDIS_URL,
+      host: "127.0.0.1",
     });
   }
 });

--- a/src/plugins/redis.ts
+++ b/src/plugins/redis.ts
@@ -12,8 +12,6 @@ export default fp(async (fastify) => {
     `echo "$( docker container inspect -f '{{.State.Running}}' "redis-partz")"`
   );
 
-  console.log(`stdout`, stdout);
-
   if (stdout.includes("true")) {
     console.log("coucou");
     fastify.register<FastifyRedisPluginOptions>(fastifyRedis, {

--- a/src/plugins/redis.ts
+++ b/src/plugins/redis.ts
@@ -1,0 +1,20 @@
+import { exec } from "child_process";
+import fp from "fastify-plugin";
+import fastifyRedis, { FastifyRedisPluginOptions } from "fastify-redis";
+
+let IS_REDIS_ONLINE: boolean;
+
+exec(
+  `echo "$( docker container inspect -f '{{.State.Running}}' "redis-partz")"`,
+  (_error, stdout) => {
+    IS_REDIS_ONLINE = stdout.includes("true");
+  }
+);
+
+export default fp(async (fastify) => {
+  if (IS_REDIS_ONLINE) {
+    fastify.register<FastifyRedisPluginOptions>(fastifyRedis, {
+      url: process.env.REDIS_URL,
+    });
+  }
+});

--- a/src/plugins/redis.ts
+++ b/src/plugins/redis.ts
@@ -3,6 +3,8 @@ import fastifyRedis, { FastifyRedisPluginOptions } from "fastify-redis";
 import { exec } from "child_process";
 import { promisify } from "util";
 
+// We need to promisify exec because using it the old way
+// with the callback crashes the server :(
 const execAwait = promisify(exec);
 
 export default fp(async (fastify) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,31 +689,6 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@node-redis/client@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@node-redis/client/-/client-1.0.1.tgz#ddca6021097ce1026fedc193cac8c36b05c6cad8"
-  integrity sha512-o0I4LdzJXP6QYxRnBPrQ7cIG5tF3SNM/PBnjC3mV6QkzIiGRElzWqSr9a9JCJdcyB1SIA80bhgGhpdTpCQ1Sdw==
-  dependencies:
-    cluster-key-slot "1.1.0"
-    generic-pool "3.8.2"
-    redis-parser "3.0.0"
-    yallist "4.0.0"
-
-"@node-redis/json@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@node-redis/json/-/json-1.0.1.tgz#8cd987c1855392adf21bc4f06163a7eda97a40a3"
-  integrity sha512-2EB96ZN0yUr4mgA9Odme48jX8eF5Ji0jrsRn4rLfEhME7L3rHLdKeUfxJKxbPOxadP6k8+6ViElxPZrKuV2nvQ==
-
-"@node-redis/search@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@node-redis/search/-/search-1.0.1.tgz#8d0936049f4858b9aefab40524ce8e5a52e5d08e"
-  integrity sha512-iA2Gw6gr0X6IfNSjTyme9W1tDlLkwQ1bPApo4s8aVwZ2Ju8Z4COVik0vT6BJPRin79f5xPZgnaec3DIoC2UpHA==
-
-"@node-redis/time-series@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@node-redis/time-series/-/time-series-1.0.0.tgz#3db4caa63d7c158f0b73ab6cd46bd6c9c187dfaf"
-  integrity sha512-QcaCIL/DlYJXedSfmjF+IRxKJbBUXBrjA5Gv0IiPlXXFFOkRnbPGKq6hmwBAAWyk1U03wyBHDFKVS3/9GnZV8g==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1742,7 +1717,7 @@ close-with-grace@^1.0.0:
   resolved "https://registry.yarnpkg.com/close-with-grace/-/close-with-grace-1.1.0.tgz#91a48cf2019b5ae6e67b0255a32abcfd9bbca233"
   integrity sha512-6cCp71Y5tKw1o9sGVBOa9OwY4vJ+YoLpFcWiTt9YCBhYlcQi0z68EiiN9mJ6/401Za6TZ5YOZg012IHHZt15lw==
 
-cluster-key-slot@1.1.0:
+cluster-key-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
   integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
@@ -2005,7 +1980,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.x, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@4.x, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -2078,7 +2053,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-denque@^1.4.1:
+denque@^1.1.0, denque@^1.4.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
   integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
@@ -2700,6 +2675,14 @@ fastify-rate-limit@^5.6.2:
     ms "^2.1.1"
     tiny-lru "^7.0.0"
 
+fastify-redis@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/fastify-redis/-/fastify-redis-4.3.3.tgz#782a6641b80a4ceb4fee21ae355c7808522beec9"
+  integrity sha512-E9OP1QSL6i/wWIOwRmSlJd7vBmTmOpSqQjvk4+SQTZ5VMBS7ANpZj+nSRm0F8MIDQFLIsTSUE7ozHibDt22R2g==
+  dependencies:
+    fastify-plugin "^3.0.0"
+    ioredis "^4.27.9"
+
 fastify-sensible@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fastify-sensible/-/fastify-sensible-3.1.2.tgz#8b8672b4c55ca17a5ae267d5953b53c141b2a380"
@@ -2981,11 +2964,6 @@ gauge@^3.0.0:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     wide-align "^1.1.2"
-
-generic-pool@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.8.2.tgz#aab4f280adb522fdfbdc5e5b64d718d3683f04e9"
-  integrity sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==
 
 generify@^4.0.0:
   version "4.2.0"
@@ -3371,6 +3349,23 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ioredis@^4.27.9:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.28.2.tgz#493ccd5d869fd0ec86c96498192718171f6c9203"
+  integrity sha512-kQ+Iv7+c6HsDdPP2XUHaMv8DhnSeAeKEwMbaoqsXYbO+03dItXt7+5jGQDRyjdRUV2rFJbzg7P4Qt1iX2tqkOg==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    lodash.isarguments "^3.1.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ip@1.1.5, ip@^1.1.5:
   version "1.1.5"
@@ -4265,10 +4260,25 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.get@^4:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -4914,6 +4924,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-map@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-map@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
@@ -5330,7 +5345,12 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-redis-errors@^1.0.0:
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
   integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
@@ -5340,22 +5360,12 @@ redis-mock@^0.56.3:
   resolved "https://registry.yarnpkg.com/redis-mock/-/redis-mock-0.56.3.tgz#e96471bcc774ddc514c2fc49cdd03cab2baecd89"
   integrity sha512-ynaJhqk0Qf3Qajnwvy4aOjS4Mdf9IBkELWtjd+NYhpiqu4QCNq6Vf3Q7c++XRPGiKiwRj9HWr0crcwy7EiPjYQ==
 
-redis-parser@3.0.0:
+redis-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
   integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
-
-redis@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-4.0.1.tgz#c020e2ac7f83f0c1d42ced50b8a7af28164bd6ee"
-  integrity sha512-qfcq1oz2ci7pNdCfTLLEuKhS8jZ17dFiT1exogOr+jd3EVP/h9qpy7K+VajB4BXA0k8q68KFqR6HrliKV6jt1Q==
-  dependencies:
-    "@node-redis/client" "^1.0.1"
-    "@node-redis/json" "^1.0.1"
-    "@node-redis/search" "^1.0.1"
-    "@node-redis/time-series" "^1.0.0"
 
 regexp-clone@1.0.0, regexp-clone@^1.0.0:
   version "1.0.0"
@@ -5765,6 +5775,11 @@ stack-utils@^2.0.3:
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -6507,15 +6522,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@4.0.0, yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"


### PR DESCRIPTION
I added back redis thanks to fastify-redis plugin. 
https://github.com/fastify/fastify-redis

I am using the exec function of nodejs to see if the container redis is running, else we dont try to register (or it crashers server)
https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback

There was an issue because exec uses the old way of asynchronous (a callback function) that was not compatible with the async function of registering plugin
Therefore, I used "promisify" function to make exec a promise and then be able to await the result